### PR TITLE
Fix BukkitRegistryAdapter

### DIFF
--- a/pineapple-common/src/main/java/sh/miles/pineapple/ReflectionUtils.java
+++ b/pineapple-common/src/main/java/sh/miles/pineapple/ReflectionUtils.java
@@ -321,16 +321,46 @@ public final class ReflectionUtils {
             return new ArrayList<>();
         }
         List<Class<?>> componentTypes = splitTypeName(typeName, ind + 1, typeName.length() - 1)
-                .stream()
-                .map((className) -> {
-                    try {
-                        return Class.forName(className);
-                    } catch (ClassNotFoundException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .collect(Collectors.toList());
+            .stream()
+            .map((className) -> {
+                try {
+                    return Class.forName(stripGenerics(className));
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .collect(Collectors.toList());
         return componentTypes;
+    }
+
+    /**
+     * Strips out generics from the input class name
+     *
+     * @param str the string of fully qualified class name e.g. com.example.MyClass{@literal <?>} or com.example.MyClass
+     * @return the generic stripped string
+     * @since 1.0.0-SNAPSHOT
+     */
+    private static String stripGenerics(String str) {
+        final StringBuilder result = new StringBuilder();
+        int depth = 0;
+
+        char cur;
+        for (int i = 0; i < str.length(); i++) {
+            cur = str.charAt(i);
+            if (cur == '<') {
+                depth++;
+            } else if (cur == '>') {
+                depth--;
+            } else if (depth == 0) {
+                result.append(cur);
+            }
+        }
+
+        if (depth > 0) {
+            throw new IllegalArgumentException("Invalid generic sequence in string %s".formatted(str));
+        }
+
+        return result.toString();
     }
 
     /**

--- a/pineapple-core/src/main/java/sh/miles/pineapple/util/serialization/adapter/bukkit/BukkitRegistryAdapter.java
+++ b/pineapple-core/src/main/java/sh/miles/pineapple/util/serialization/adapter/bukkit/BukkitRegistryAdapter.java
@@ -1,5 +1,7 @@
 package sh.miles.pineapple.util.serialization.adapter.bukkit;
 
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -22,9 +24,9 @@ class BukkitRegistryAdapter<R extends Keyed> implements SerializedAdapter<R> {
     private final Class<R> registryClass;
     private final Registry<R> registry;
 
-    public BukkitRegistryAdapter(Class<R> registryClass) {
+    public BukkitRegistryAdapter(Class<R> registryClass, RegistryKey<R> key) {
         this.registryClass = registryClass;
-        this.registry = Bukkit.getRegistry(registryClass);
+        this.registry = RegistryAccess.registryAccess().getRegistry(key);
     }
 
     @NotNull
@@ -54,11 +56,11 @@ class BukkitRegistryAdapter<R extends Keyed> implements SerializedAdapter<R> {
 
     static List<BukkitRegistryAdapter<?>> getRegistryAdapters() {
         final List<BukkitRegistryAdapter<?>> list = new ArrayList<>();
-
         try {
-            for (final Field field : Registry.class.getDeclaredFields()) {
-                if (field.getName().equals("MEMORY_MODULE_TYPE")) continue; // TODO handle generics here instead of skipping
-                list.add(new BukkitRegistryAdapter(ReflectionUtils.getParameterizedTypes(field).getFirst()));
+            for (final Field field : RegistryKey.class.getDeclaredFields()) {
+                list.add(new BukkitRegistryAdapter(ReflectionUtils.getParameterizedTypes(field).getFirst(),
+                    (RegistryKey) field.get(null)
+                ));
             }
         } catch (Exception ignored) { // while not usually advised we need to catch an exception here for Unit Test
             ignored.printStackTrace();


### PR DESCRIPTION
Fixes BukkitRegistryAdapter, by stripping generics from key classes and redirecting retrieval to the new RegistryAccess system from paper